### PR TITLE
Fix webpack performance warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -189,15 +189,20 @@ module.exports = (env) => {
 	return merge(defaultConfig, {
 		mode,
 		entry: entries,
-		output: {
-			path: path.resolve(__dirname, "build"),
-			filename: "[name].js",
-			assetModuleFilename: "images/[path][name][ext]",
-		},
-		plugins,
-		stats: {
-			all: false,
-			source: true,
+                output: {
+                        path: path.resolve(__dirname, "build"),
+                        filename: "[name].js",
+                        assetModuleFilename: "images/[path][name][ext]",
+                },
+                plugins,
+                // Disable performance hints to avoid asset size warnings during
+                // the build process.
+                performance: {
+                        hints: false,
+                },
+                stats: {
+                        all: false,
+                        source: true,
 			assets: true,
 			errorsCount: true,
 			errors: true,


### PR DESCRIPTION
## Summary
- silence large asset warnings during webpack build by disabling performance hints

## Testing
- `npm run build`
- `npm run lint:css` *(fails: at-rule-empty-line-before)*
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_6840a7c599748322a47c2b5a9eae4aba