### PR TITLE
Add pattern markup validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Additional commands:
 - `npm run lint:css` – run Stylelint over the SCSS sources.
 - `npm run lint:js` – run ESLint on the JavaScript sources.
 - `npm run zip` – create a distributable `upa25.zip` in the repository root.
+- `npm run test:patterns` – validate that block pattern markup parses correctly.
 
 ## Repository Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"gsap": "^3.12.5"
 			},
 			"devDependencies": {
+				"@wordpress/block-serialization-default-parser": "^5.25.0",
 				"@wordpress/scripts": "^30.11.0",
 				"copy-webpack-plugin": "^12.0.2",
 				"glob": "^11.0.0",
@@ -5551,6 +5552,20 @@
 			"integrity": "sha512-+/7ZojzWiC5TqXT6l+59NhjxPKoTALo9zkqSkphWDTkl/eNrZH7T99/btrak48sBcxmxV5SOpTe4OoV5QYl0nA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-serialization-default-parser": {
+			"version": "5.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.25.0.tgz",
+			"integrity": "sha512-tQWAbTY/5Rsv5H544qV7JEq5sjVfXFWiZSrXdb4Tnhs2K40LbJEKuYBcnJXo99zh0UHcX3Gw2h3qIBLSCaLC4A==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7"
+			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
 		"build": "wp-scripts build --config webpack.config.js --env production",
 		"lint:css": "wp-scripts lint-style 'src/scss/*'",
 		"lint:css:fix": "wp-scripts lint-style 'src/scss/*' --fix",
-		"lint:js": "wp-scripts lint-js 'src/js/*'",
-		"format": "wp-scripts format 'src/**/*.{js,jsx,json,ts,tsx,css,scss,php}' '!src/fonts/**'",
-		"zip": "wp-scripts plugin-zip",
-		"packages-update": "wp-scripts packages-update"
-	},
+                "lint:js": "wp-scripts lint-js 'src/js/*'",
+                "format": "wp-scripts format 'src/**/*.{js,jsx,json,ts,tsx,css,scss,php}' '!src/fonts/**'",
+                "zip": "wp-scripts plugin-zip",
+                "packages-update": "wp-scripts packages-update",
+                "test:patterns": "node scripts/validate-patterns.js"
+        },
 	"files": [
 		"/*",
 		"!/upa25",
@@ -27,6 +28,7 @@
 	"license": "GPL-2.0",
 	"description": "",
 	"devDependencies": {
+		"@wordpress/block-serialization-default-parser": "^5.25.0",
 		"@wordpress/scripts": "^30.11.0",
 		"copy-webpack-plugin": "^12.0.2",
 		"glob": "^11.0.0",

--- a/scripts/validate-patterns.js
+++ b/scripts/validate-patterns.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const { parse } = require('@wordpress/block-serialization-default-parser');
+
+const files = glob.sync(path.join(__dirname, '../patterns/**/*.php'));
+let hasError = false;
+
+function sanitize(content) {
+  if (content.startsWith('<?php')) {
+    const idx = content.indexOf('?>');
+    if (idx !== -1) {
+      content = content.slice(idx + 2);
+    }
+  }
+  return content.replace(/<\?php[\s\S]*?\?>/g, '');
+}
+
+for (const file of files) {
+  const data = fs.readFileSync(file, 'utf8');
+  const markup = sanitize(data);
+  try {
+    parse(markup);
+  } catch (e) {
+    hasError = true;
+    console.error(`Invalid markup in ${file}: ${e.message}`);
+  }
+}
+
+if (hasError) {
+  console.error('Pattern validation failed.');
+  process.exit(1);
+} else {
+  console.log('All pattern markup is valid.');
+}


### PR DESCRIPTION
## Summary
- validate pattern markup using WordPress default parser
- add `test:patterns` npm script
- document the pattern validation script in the README

## Testing
- `npm run test:patterns`


------
https://chatgpt.com/codex/tasks/task_e_6840b17bca948322a68d672711437e5f